### PR TITLE
Fix advancing 32 instead of 1 byte after consuming a bytes1..bytes32

### DIFF
--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -525,4 +525,35 @@ mod tests {
 			]
 		);
 	}
+
+	#[test]
+	fn decode_after_fixed_bytes_with_less_than_32_bytes() {
+		let encoded = hex!("
+			0000000000000000000000008497afefdc5ac170a664a231f6efb25526ef813f
+			0000000000000000000000000000000000000000000000000000000000000000
+			0000000000000000000000000000000000000000000000000000000000000000
+			0000000000000000000000000000000000000000000000000000000000000080
+			000000000000000000000000000000000000000000000000000000000000000a
+			3078303030303030314600000000000000000000000000000000000000000000
+		");
+
+		assert_eq!(
+			decode(
+				&[
+					ParamType::Address,
+					ParamType::FixedBytes(32),
+					ParamType::FixedBytes(4),
+					ParamType::String,
+				],
+				&encoded,
+			)
+			.unwrap(),
+			&[
+				Token::Address(hex!("8497afefdc5ac170a664a231f6efb25526ef813f").into()),
+				Token::FixedBytes([0u8; 32].to_vec()),
+				Token::FixedBytes([0u8; 4].to_vec()),
+				Token::String("0x0000001F".into()),
+			]
+		);
+	}
 }

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -115,6 +115,8 @@ fn decode_param(param: &ParamType, data: &[u8], offset: usize) -> Result<DecodeR
 			Ok(result)
 		}
 		ParamType::FixedBytes(len) => {
+			// FixedBytes is anything from bytes1 to bytes32. These values
+			// are padded with trailing zeros to fill 32 bytes.
 			let bytes = take_bytes(data, offset, len)?;
 			let result = DecodeResult {
 				token: Token::FixedBytes(bytes),

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -118,7 +118,7 @@ fn decode_param(param: &ParamType, data: &[u8], offset: usize) -> Result<DecodeR
 			let bytes = take_bytes(data, offset, len)?;
 			let result = DecodeResult {
 				token: Token::FixedBytes(bytes),
-				new_offset: offset + len,
+				new_offset: offset + 32,
 			};
 			Ok(result)
 		}


### PR DESCRIPTION
This fixes the root cause of https://github.com/graphprotocol/graph-node/issues/801. Fixed bytes are always 32 bytes, regardless of whether they are `bytes`, `bytes5` or `bytes32`. They are padded with zeros. That's why it was wrong to only increment the offset by one byte.