### PR TITLE
Use lossy UTF-8 decoding for strings

### DIFF
--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -143,6 +143,10 @@ fn decode_param(
 			let len = as_usize(&peek_32_bytes(data, dynamic_offset)?)?;
 			let bytes = take_bytes(data, dynamic_offset + 32, len)?;
 			let result = DecodeResult {
+				// NOTE: We're decoding strings using lossy UTF-8 decoding to
+				// prevent invalid strings written into contracts by either users or
+				// Solidity bugs from causing graph-node to fail decoding event
+				// data.
 				token: Token::String(String::from_utf8_lossy(&*bytes).into()),
 				new_offset: offset + 32,
 			};

--- a/ethabi/src/decoder.rs
+++ b/ethabi/src/decoder.rs
@@ -143,7 +143,7 @@ fn decode_param(
 			let len = as_usize(&peek_32_bytes(data, dynamic_offset)?)?;
 			let bytes = take_bytes(data, dynamic_offset + 32, len)?;
 			let result = DecodeResult {
-				token: Token::String(String::from_utf8(bytes)?),
+				token: Token::String(String::from_utf8_lossy(&*bytes).into()),
 				new_offset: offset + 32,
 			};
 			Ok(result)
@@ -792,6 +792,22 @@ mod tests {
 				Token::FixedBytes([0u8; 4].to_vec()),
 				Token::String("0x0000001F".into()),
 			]
+		);
+	}
+
+	#[test]
+	fn decode_broken_utf8() {
+		let encoded = hex!(
+			"
+			0000000000000000000000000000000000000000000000000000000000000020
+			0000000000000000000000000000000000000000000000000000000000000004
+			e4b88de500000000000000000000000000000000000000000000000000000000
+        "
+		);
+
+		assert_eq!(
+			decode(&[ParamType::String,], &encoded).unwrap(),
+			&[Token::String("不�".into())]
 		);
 	}
 }


### PR DESCRIPTION
This makes the decoding a little more tolerant to UTF-8 encoding errors, which might not be the user's or contract author's fault.

One example is the string parameter in the `Apply` event on https://etherscan.io/tx/0x13d400e7d06fe4b88d93a28d6974654604c3eb24b726f0671ee793add8b6c459#eventlog

It is not valid UTF-8, so something must've gone wrong on either the user's side or in the contract. Rather than failing to decode this event data, lossy UTF-8 allows us to decode it as "不�" and move on.

This resolves a bug reported by `@nicosampler` on Discord.