### PR TITLE
Add support for overloaded functions

### DIFF
--- a/cli/src/error.rs
+++ b/cli/src/error.rs
@@ -25,5 +25,16 @@ error_chain! {
 			description("More than one event found for name, try providing the full signature"),
 			display("Ambiguous event name `{}`", name),
 		}
+
+		InvalidFunctionSignature(signature: String) {
+			description("Invalid function signature"),
+			display("Invalid function signature `{}`", signature),
+		}
+
+		AmbiguousFunctionName(name: String) {
+			description("More than one function found for name, try providing the full signature"),
+			display("Ambiguous function name `{}`", name),
+		}
+
 	}
 }

--- a/ethabi/src/contract.rs
+++ b/ethabi/src/contract.rs
@@ -14,7 +14,7 @@ pub struct Contract {
 	/// Contract constructor.
 	pub constructor: Option<Constructor>,
 	/// Contract functions.
-	pub functions: HashMap<String, Function>,
+	pub functions: HashMap<String, Vec<Function>>,
 	/// Contract events, maps signature to event.
 	pub events: HashMap<String, Vec<Event>>,
 	/// Contract has fallback function.
@@ -50,7 +50,7 @@ impl<'a> Visitor<'a> for ContractVisitor {
 					result.constructor = Some(constructor);
 				},
 				Operation::Function(func) => {
-					result.functions.insert(func.name.clone(), func);
+					result.functions.entry(func.name.clone()).or_default().push(func);
 				},
 				Operation::Event(event) => {
 					result.events.entry(event.name.clone()).or_default().push(event);
@@ -76,9 +76,15 @@ impl Contract {
 		self.constructor.as_ref()
 	}
 
-	/// Creates function call builder.
+	/// Get the function named `name`, the first if there are overloaded
+	/// versions of the same function.
 	pub fn function(&self, name: &str) -> errors::Result<&Function> {
-		self.functions.get(name).ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
+		self.functions
+			.get(name)
+			.into_iter()
+			.flatten()
+			.next()
+			.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}
 
 	/// Get the contract event named `name`, the first if there are multiple.
@@ -95,9 +101,16 @@ impl Contract {
 					.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
 	}
 
+	/// Get all functions named `name`.
+	pub fn functions_by_name(&self, name: &str) -> errors::Result<&Vec<Function>> {
+		self.functions
+			.get(name)
+			.ok_or_else(|| ErrorKind::InvalidName(name.to_owned()).into())
+	}
+
 	/// Iterate over all functions of the contract in arbitrary order.
 	pub fn functions(&self) -> Functions {
-		Functions(self.functions.values())
+		Functions(self.functions.values().flatten())
 	}
 
 	/// Iterate over all events of the contract in arbitrary order.
@@ -112,7 +125,7 @@ impl Contract {
 }
 
 /// Contract functions interator.
-pub struct Functions<'a>(Values<'a, String, Function>);
+pub struct Functions<'a>(Flatten<Values<'a, String, Vec<Function>>>);
 
 impl<'a> Iterator for Functions<'a> {
 	type Item = &'a Function;

--- a/ethabi/src/function.rs
+++ b/ethabi/src/function.rs
@@ -1,5 +1,7 @@
 //! Contract function call builder.
 
+use std::string::ToString;
+
 use signature::short_signature;
 use {Param, Token, Result, ErrorKind, Bytes, decode, ParamType, encode};
 
@@ -53,6 +55,32 @@ impl Function {
 	/// Parses the ABI function input to a list of tokens.
 	pub fn decode_input(&self, data: &[u8]) -> Result<Vec<Token>> {
 		decode(&self.input_param_types(), &data)
+	}
+
+	/// Returns a signature that uniquely identifies this function.
+	///
+	/// Examples:
+	/// - `functionName()`
+	/// - `functionName():(uint256)`
+	/// - `functionName(bool):(uint256,string)`
+	/// - `functionName(uint256,bytes32):(string,uint256)`
+	pub fn signature(&self) -> String {
+		let inputs = self.inputs
+			.iter()
+			.map(|p| p.kind.to_string())
+			.collect::<Vec<_>>()
+			.join(",");
+
+		let outputs = self.outputs
+			.iter()
+			.map(|p| p.kind.to_string())
+			.collect::<Vec<_>>()
+			.join(",");
+
+		match (inputs.len(), outputs.len()) {
+			(_, 0) => format!("{}({})", self.name, inputs),
+			(_, n) => format!("{}({}):({})", self.name, inputs, outputs)
+		}
 	}
 }
 

--- a/res/test.abi
+++ b/res/test.abi
@@ -9,5 +9,33 @@
         "name": "foo",
         "outputs": [],
         "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "a",
+                "type": "bool"
+            }
+        ],
+        "name": "bar",
+        "outputs": [
+        ],
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "name": "a",
+                "type": "string"
+            }
+        ],
+        "name": "bar",
+        "outputs": [
+            {
+                "name": "b",
+                "type": "uint256"
+            }
+        ],
+        "type": "function"
     }
 ]


### PR DESCRIPTION
Prior to this, ethabi would store just on function definition per function name in the `Contract` struct. This is not sufficient, as functions can be overloaded and there can be multiple definitions with the same name.

This applies the same treatment to contract functions that was applied earlier for events: for every name, a vector of function definitions is now stored. ethabi-cli takes either a name or a signature of the form

    functionName()
    functionName():(bool)
    functionName(uint256,string):(uint256,bool)

and matches this to the right overloaded version of the function with that name.

Also submitted upstream: https://github.com/paritytech/ethabi/pull/166.