### PR TITLE
Support deserializing Event operations with tuple[] type inputs

### DIFF
--- a/ethabi/src/event_param.rs
+++ b/ethabi/src/event_param.rs
@@ -82,14 +82,35 @@ impl<'a> Visitor<'a> for EventParamVisitor {
 			}
 		}
 		let name = name.ok_or_else(|| Error::missing_field("name"))?;
-		let kind = kind.ok_or_else(|| Error::missing_field("kind")).and_then(|param_type| {
-			if let ParamType::Tuple(_) = param_type {
-				let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
-				Ok(ParamType::Tuple(tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect()))
-			} else {
-				Ok(param_type)
-			}
-		})?;
+		let kind =
+			kind.ok_or_else(|| Error::missing_field("kind")).and_then(|param_type: ParamType| match param_type {
+				ParamType::Tuple(_) => {
+					let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
+					Ok(ParamType::Tuple(tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect()))
+				}
+				ParamType::Array(inner_param_type) => match *inner_param_type {
+					ParamType::Tuple(_) => {
+						let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
+						Ok(ParamType::Array(Box::new(ParamType::Tuple(
+							tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect(),
+						))))
+					}
+					_ => Ok(ParamType::Array(inner_param_type)),
+				},
+				ParamType::FixedArray(inner_param_type, size) => match *inner_param_type {
+					ParamType::Tuple(_) => {
+						let tuple_params = components.ok_or_else(|| Error::missing_field("components"))?;
+						Ok(ParamType::FixedArray(
+							Box::new(ParamType::Tuple(
+								tuple_params.into_iter().map(|param| param.kind).map(Box::new).collect(),
+							)),
+							size,
+						))
+					}
+					_ => Ok(ParamType::FixedArray(inner_param_type, size)),
+				},
+				_ => Ok(param_type),
+			})?;
 		let indexed = indexed.unwrap_or(false);
 		Ok(EventParam { name, kind, indexed })
 	}

--- a/ethabi/src/operation.rs
+++ b/ethabi/src/operation.rs
@@ -66,7 +66,7 @@ impl<'a> Deserialize<'a> for Operation {
 #[cfg(test)]
 mod tests {
 	use super::Operation;
-	use crate::{Function, Param, ParamType, StateMutability};
+	use crate::{Event, EventParam, Function, Param, ParamType, StateMutability};
 	use serde_json;
 
 	#[test]
@@ -91,6 +91,68 @@ mod tests {
 				outputs: vec![],
 				constant: false,
 				state_mutability: StateMutability::NonPayable,
+			})
+		);
+	}
+
+	#[test]
+	fn deserialize_event_operation_with_tuple_array_input() {
+		let s = r#"{
+			"type":"event",
+			"inputs": [
+				{
+					"name":"a",
+					"type":"address",
+					"indexed":true
+				},
+				{
+				  "components": [
+					{
+					  "internalType": "address",
+					  "name": "to",
+					  "type": "address"
+					},
+					{
+					  "internalType": "uint256",
+					  "name": "value",
+					  "type": "uint256"
+					},
+					{
+					  "internalType": "bytes",
+					  "name": "data",
+					  "type": "bytes"
+					}
+				  ],
+				  "indexed": false,
+				  "internalType": "struct Action[]",
+				  "name": "b",
+				  "type": "tuple[]"
+				}
+			],
+			"name":"E",
+			"outputs": [],
+			"anonymous": false
+		}"#;
+
+		let deserialized: Operation = serde_json::from_str(s).unwrap();
+
+		assert_eq!(
+			deserialized,
+			Operation::Event(Event {
+				name: "E".to_owned(),
+				inputs: vec![
+					EventParam { name: "a".to_owned(), kind: ParamType::Address, indexed: true },
+					EventParam {
+						name: "b".to_owned(),
+						kind: ParamType::Array(Box::new(ParamType::Tuple(vec![
+							Box::new(ParamType::Address),
+							Box::new(ParamType::Uint(256)),
+							Box::new(ParamType::Bytes)
+						]))),
+						indexed: false
+					},
+				],
+				anonymous: false,
 			})
 		);
 	}


### PR DESCRIPTION
Resolves an issue deserializing contract ABIs with `tuple[]` type event inputs.  

The issue stemmed from the special cases of `ParamType::Array(ParamType::Tuple([])` and `ParamType::FixedArray(ParamType::Tuple([]))` types not being handled when deserializing event param inputs.